### PR TITLE
Change icon to notification-symbolic from notifications-symbolic

### DIFF
--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -129,7 +129,7 @@ const 	NotificationCenter = new Lang.Class({
 
     	loadDndStatus: function ()
  	{
-		this.icon.icon_name = Gtk.IconTheme.get_default().has_icon("notifications-symbolic")?"notifications-symbolic":"preferences-system-notifications-symbolic";
+		this.icon.icon_name = Gtk.IconTheme.get_default().has_icon("notification-symbolic")?"notification-symbolic":"preferences-system-notifications-symbolic";
                 if(this.dndpref.get_boolean('show-banners')==true)
 		{
 			this.dnditem.setToggleState(false);


### PR DESCRIPTION
Hi, I checked about 2 dozen themes and in all the notification-symbolic (singular) exists vs notifications-symbolic (plural) whihc I only found in la-capitaine-icon-theme and macOS-iCons. The plural version does not exist in default Gnome icon theme of Adwaita either.

The notification-symbolic (singular) is a commonaly a bell in most extensions while the fallback of preferences-system-notifications-symbolic is not and in a large number of themes seems to be unfriendly to dark version (not sure why, likely because it's commonly used in control center?) ... see Materia theme icon: https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/master/Papirus/symbolic/apps/preferences-system-notifications-symbolic.svg

Would you consider changing the icon to singular, I think it will help the icon be visible a bit more in various themes?