### PR TITLE
add style_class to the panel button

### DIFF
--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -105,6 +105,7 @@ const NotificationCenter = new Lang.Class({
     this.scrollView = (Config.PACKAGE_VERSION < "3.36") ? new St.ScrollView({hscrollbar_policy:2,x_fill:true,y_fill:true,style:"min-width:"+(this._messageList.actor.width/scaleFactor)+"px;max-height: "+0.01*this.prefs.get_int("max-height")*Main.layoutManager.monitors[0].height+"px; max-width: "+(this._messageList.actor.width/scaleFactor)+"px; padding: 0px;"}) : new St.ScrollView({hscrollbar_policy:2,x_fill:true,y_fill:true,style:"min-width:"+(this._messageList.width/scaleFactor)+"px;max-height: "+0.01*this.prefs.get_int("max-height")*Main.layoutManager.monitors[0].height+"px; max-width: "+(this._messageList.width/scaleFactor)+"px; padding: 0px;"});
     
     this.panelButtonActor = (Config.PACKAGE_VERSION < "3.34") ? this.actor : this;
+    this.panelButtonActor.add_style_class_name('notification-center-panel-button');
     
 
   },


### PR DESCRIPTION
Hello,

I'm creating a new gnome-shell theme and since the notification-center is a key object in my panel design I would like to style this button differently than the other buttons on panel.

But since the button itself has only the `panel-button` if I style it on theme, it will style the other buttons as well, so adding a second style_class to it solve the problem, so I can style it without applying to the other extension buttons.

Thanks very much,