### PR TITLE
add option to change the icon if there is notification

### DIFF
--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -395,12 +395,8 @@ const NotificationCenter = new Lang.Class({
 
     let iconName = statusIcon ? "notification-center-full" : "notification-center-empty";
 
-    if ( Gtk.IconTheme.get_default().has_icon(iconName) ) {
-        this.notificationIcon.icon_name = iconName;
-    } else {
-        this.notificationIcon.icon_name = this.notificationIconName;
-    }
-
+    this.notificationIcon.icon_name = iconName;
+    
   },
 
   middleClickDndToggle: function (actor, event) {

--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -374,6 +374,10 @@ const NotificationCenter = new Lang.Class({
     this.notificationLabel.visible = nCount*this.newNotificationAction;
     this.eventsLabel.visible = eCount*this.newNotificationAction;
 
+    if (this.prefs.get_boolean("change-icons")) {
+        this.manageIconChange(nCount > 0 || eCount > 0);
+    }
+
     if(this.newNotificationAction == 2) {
 
         if(nCount>0) {
@@ -383,6 +387,18 @@ const NotificationCenter = new Lang.Class({
           this.eventsLabel.text=eCount.toString()+" ";
         }
 
+    }
+
+  },
+
+  manageIconChange: function(statusIcon) {
+
+    let iconName = statusIcon ? "notification-center-full" : "notification-center-empty";
+
+    if ( Gtk.IconTheme.get_default().has_icon(iconName) ) {
+        this.notificationIcon.icon_name = iconName;
+    } else {
+        this.notificationIcon.icon_name = this.notificationIconName;
     }
 
   },

--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -273,6 +273,7 @@ const NotificationCenter = new Lang.Class({
 
     if(this.isDndOff) {
       this.notificationIcon.set_opacity(255);
+      this.manageLabel();
       return false;
 
     }

--- a/notification-center@Selenium-H/prefs.js
+++ b/notification-center@Selenium-H/prefs.js
@@ -103,6 +103,7 @@ const AboutPage = new GObject.Class({
 		settings.reset("autohide"               );
 		settings.reset("indicator-shortcut"     );
 		settings.reset("new-notification"       );
+		settings.reset("change-icons"           );
 		settings.reset("include-events-count"   );
 		settings.reset("blink-icon"             );
 		settings.reset("blink-time"             );
@@ -417,6 +418,7 @@ const PrefsWindowForIndicator =  new GObject.Class({
     this.prefComboInt("autohide",                pos++, ['0','1','2'],                             [_("No"),_("Yes"),_("If Do Not Disturb is Off")]                );
     this.prefStr     ("indicator-shortcut",      pos++, ['<Alt>', '<Ctrl>', '<Shift>', '<Super>'], [_('Alt Key'), _('Ctrl Key'), _('Shift Key'), _('Super Key')]   );
     this.prefCombo   ("new-notification",        pos++, ['none', 'dot', 'count'],                  [_('Show Nothing'), _('Show Dot'), _('Show Count')]             );
+    this.prefSwitch  ("change-icons",            pos++                                                                                                             );
     this.prefSwitch  ("include-events-count",    pos++                                                                                                             );
     this.prefTime    ("blink-icon",              pos++,    0,     10000,       1                                                                                   );
     this.prefTime    ("blink-time",              pos++,    100,   10000,       10                                                                                  );

--- a/schemas/org.gnome.shell.extensions.notification-center.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.notification-center.gschema.xml
@@ -198,6 +198,12 @@ Version 18
       <description>Signals the extension to reload</description>
     </key>   
      
+    <key name="change-icons" type="b">
+      <default>false</default>
+      <summary>Change icons depending if there is notification or not</summary>
+      <description>Change icons depending if there is notification or not</description>
+    </key>
+   
   </schema>
   
 </schemalist>


### PR DESCRIPTION
Hello,

Thanks for this awesome extension, I would like to provide a new functionality: change the icon if there is notification

![image](https://user-images.githubusercontent.com/11244067/89617058-e1cca780-d85f-11ea-9f12-064bc21198bc.png)

In this case I defined two icon names for this: `notification-center-full` and `notification-center-empty` it will work if there are those icon on icon theme, otherwise it will display the default icon.

I'm creating also an icon theme and I will provide these two icons on it.

Hope you like it,
Thanks