### PR TITLE
Add option to hide date.

### DIFF
--- a/locale/notification-center.pot
+++ b/locale/notification-center.pot
@@ -342,3 +342,8 @@ msgstr ""
 #: schemas/org.gnome.shell.extensions.notification-center.gschema.xml:240
 msgid "Signals the extension to reload profiles"
 msgstr ""
+
+#: schemas/org.gnome.shell.extensions.notification-center.gschema.xml:245
+#: schemas/org.gnome.shell.extensions.notification-center.gschema.xml:246
+msgid "Hide Date Section"
+msgstr ""

--- a/notification-center@Selenium-H/extension.js
+++ b/notification-center@Selenium-H/extension.js
@@ -732,8 +732,10 @@ const NotificationCenter = new Lang.Class({
     Main.panel.statusArea.dateMenu._weatherItem.visible = !this.prefs.get_boolean("hide-weather-section") && this.defaultWeatherItemVisibility;
      
     this.defaultClocksItemVisibility = Main.panel.statusArea.dateMenu._clocksItem.visible; 
-    Main.panel.statusArea.dateMenu._clocksItem.visible =  !this.prefs.get_boolean("hide-clock-section") && this.defaultClocksItemVisibility; 
+    Main.panel.statusArea.dateMenu._clocksItem.visible =  !this.prefs.get_boolean("hide-clock-section") && this.defaultClocksItemVisibility;
     
+    this.defaultDateVisibility = Main.panel.statusArea.dateMenu._date.visible; 
+    Main.panel.statusArea.dateMenu._date.visible =  !this.prefs.get_boolean("hide-date-section") && this.defaultDateVisibility; 
     
   },
   
@@ -803,6 +805,7 @@ const NotificationCenter = new Lang.Class({
 
     Main.panel.statusArea.dateMenu._weatherItem.visible = this.defaultWeatherItemVisibility;
     Main.panel.statusArea.dateMenu._clocksItem.visible  = this.defaultClocksItemVisibility;
+    Main.panel.statusArea.dateMenu._date.visible        = this.defaultDateVisibility;
 
     Main.wm.removeKeybinding('indicator-shortcut');
 

--- a/notification-center@Selenium-H/prefs.js
+++ b/notification-center@Selenium-H/prefs.js
@@ -107,6 +107,7 @@ const AboutPage_NotificationCenterExtension = new GObject.Class({
     settings.reset("sections-order");
     settings.reset("hide-clock-section");
     settings.reset("hide-weather-section");
+    settings.reset("hide-date-section");
 
     settings.reset("indicator-pos");
     settings.reset("indicator-index");
@@ -537,6 +538,7 @@ const PrefsWindowForNotifications_NotificationCenterExtension =  new GObject.Cla
     this.prefTime  ("max-height",                   pos++, 20,  100, 1                                                                                                );
     this.prefSwitch("hide-clock-section",           pos++                                                                                                             );
     this.prefSwitch("hide-weather-section",         pos++                                                                                                             );
+    this.prefSwitch("hide-date-section",            pos++                                                                                                             );
     this.prefCombo ("banner-pos",                   pos++, ['left','center','right' ],       [_('Left'), _('Center'), _('Right')]                                     );  
     
   },

--- a/schemas/org.gnome.shell.extensions.notification-center.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.notification-center.gschema.xml
@@ -128,7 +128,7 @@ Version 20.02
       <default>false</default>
       <summary>Hide Weather Section</summary>
       <description>Hide Weather Section</description>
-    </key>    
+    </key>   
     
     <key enum="org.gnome.shell.extensions.notification-center.banner-pos" name="banner-pos">
       <default>'right'</default>
@@ -239,6 +239,12 @@ Version 20.02
       <summary>Signals the extension to reload profiles </summary>
       <description>Signals the extension to reload profiles</description>
     </key>      
+   
+    <key name="hide-date-section" type="b">
+      <default>false</default>
+      <summary>Hide Date Section</summary>
+      <description>Hide Date Section</description>
+    </key>  
         
   </schema>
   


### PR DESCRIPTION
Would you be willing to add an option to your extension to hide the date that is above the calendar?

Here is a preview of what it would look like:

<img width="1440" alt="Screen Shot 2021-01-19 at 5 19 01 PM" src="https://user-images.githubusercontent.com/9434919/105106018-e0441400-5a7a-11eb-8513-f36229534971.png">
